### PR TITLE
Allow for inline strings in "it should pass|fail with"

### DIFF
--- a/features/testing_behat_in_behat.feature
+++ b/features/testing_behat_in_behat.feature
@@ -46,6 +46,7 @@ Feature: Testing Behat in Behat
                 Then it passes with output "Krzysztof Krawczyk"
         """
         When I run Behat
+        Then it should pass with "Krzysztof Krawczyk"
         Then it should pass with:
         """
         Krzysztof Krawczyk
@@ -71,6 +72,7 @@ Feature: Testing Behat in Behat
                 Then it fails with output "Krzysztof Krawczyk"
         """
         When I run Behat
+        Then it should fail with "Krzysztof Krawczyk"
         Then it should fail with:
         """
         Krzysztof Krawczyk

--- a/src/Context/TestContext.php
+++ b/src/Context/TestContext.php
@@ -113,8 +113,9 @@ final class TestContext implements Context
 
     /**
      * @Then it should pass with:
+     * @Then it should pass with :expectedOutput
      */
-    public function itShouldPassWith(PyStringNode $expectedOutput)
+    public function itShouldPassWith($expectedOutput)
     {
         $this->itShouldPass();
         $this->assertOutputMatches((string) $expectedOutput);
@@ -136,8 +137,9 @@ final class TestContext implements Context
 
     /**
      * @Then it should fail with:
+     * @Then it should fail with :expectedOutput
      */
-    public function itShouldFailWith(PyStringNode $expectedOutput)
+    public function itShouldFailWith($expectedOutput)
     {
         $this->itShouldFail();
         $this->assertOutputMatches((string) $expectedOutput);


### PR DESCRIPTION
Fixes #5.
