### PR TITLE
Ensure behat output messages language

### DIFF
--- a/src/Context/TestContext.php
+++ b/src/Context/TestContext.php
@@ -190,7 +190,7 @@ FEA
      */
     public function iRunBehat()
     {
-        $this->process = new Process(sprintf('%s %s --strict -vvv --no-interaction', self::$phpBin, escapeshellarg(BEHAT_BIN_PATH)));
+        $this->process = new Process(sprintf('%s %s --strict -vvv --no-interaction --lang=en', self::$phpBin, escapeshellarg(BEHAT_BIN_PATH)));
         $this->process->setWorkingDirectory(self::$workingDir);
         $this->process->start();
         $this->process->wait();


### PR DESCRIPTION
As there are also steps for checking output text, we should be 100% sure anybody could use them - even if their uses other language in console than English.